### PR TITLE
[FIX] 뒤로 갈때 추천결과가 안보이는 이슈 해결

### DIFF
--- a/stop-ramen/src/components/AIResultBox.vue
+++ b/stop-ramen/src/components/AIResultBox.vue
@@ -35,7 +35,6 @@ const recipe = store.pageData.recipes.find(item => item.recipeTitle === props.re
 const goToRecipeDetailPage = () => {
     store.setCurrentPage('RECIPE_DETAIL', recipe); 
     store.selectedRecipeName = props.recipeName;
-    console.log("recipe::", recipe)
     router.push('/recipe-detail');
 
 }

--- a/stop-ramen/src/components/RecipeDetailBox.vue
+++ b/stop-ramen/src/components/RecipeDetailBox.vue
@@ -25,7 +25,7 @@
 import { usePageStore } from '../stores/PageStore';
 
 const store = usePageStore(); 
-const selectedRecipe = store.pageData;
+const selectedRecipe = store.detailData;
 </script>
 
 <style scoped>

--- a/stop-ramen/src/stores/PageStore.js
+++ b/stop-ramen/src/stores/PageStore.js
@@ -4,12 +4,17 @@ export const usePageStore = defineStore('page', {
   state: () => ({
     currentPage: 'SELECT_OPTION',
     pageData: null,
+    detailData: null,
     selectedRecipeName: null,
   }),
   actions: {
     setCurrentPage(page, data) {
       this.currentPage = page
-      this.pageData = data
+      if (page == 'AI_RESULT') {
+        this.pageData = data
+      } else {
+        this.detailData = data
+      }
     },
     getCurrentRoute() {
       switch (this.currentPage) {


### PR DESCRIPTION
## 📝 작업 내용
### ⬛️ 이슈 내용
-  뒤로 갈때 상세 데이터가 매핑이 되어 보여지고 있어, 데이터가 제대로 안나오는 현상 발생

### ⬛️ 이슈 발생 원인
- store에서 하나의 변수로 데이터를 관리하고 있어 페이지가 변경할때마다 그 화면에 대한 데이터로 update하는 방식이었음
- 그러다보니 뒤로가기시 이전 화면에 대한 데이터가 나오기 때문에 데이터가 제대로 나오지 않았음

### ⬛️ 해결 방법
페이지의 상태에 따라 pinia에 저장되는 변수를 다르게 하여 페이지마다 다른 데이터가 나오도록 수정

## 📸 스크린샷 

https://github.com/user-attachments/assets/ae69a185-6e08-45fd-a682-a055a55c533d


